### PR TITLE
Add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.1)
+project(eglinfo VERSION 0.1)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(GNUInstallDirs)
+
+option(USE_INTERNAL_HEADERS "Using internal Khronos EGL headers." OFF)
+
+set(EGLINFO_SOURCES main.cpp)
+if (USE_INTERNAL_HEADERS)
+    message(STATUS "Using internal Khronos EGL headers.")
+    set(EGLINFO_INCLUDE_DIRECTORIES 3rdparty/khronos)
+    set(EGLINFO_LIBRARIES -lEGL)
+else ()
+    find_package(EGL REQUIRED)
+    message(STATUS "Using system EGL headers.")
+    set(EGLINFO_INCLUDE_DIRECTORIES ${EGL_INCLUDE_DIRS})
+    set(EGLINFO_LIBRARIES ${EGL_LIBRARIES})
+    add_definitions(${EGL_DEFINITIONS})
+endif ()
+
+add_executable(eglinfo ${EGLINFO_SOURCES})
+set_property(TARGET eglinfo PROPERTY CXX_STANDARD 11)
+target_include_directories(eglinfo PUBLIC ${EGLINFO_INCLUDE_DIRECTORIES})
+target_link_libraries (eglinfo ${EGLINFO_LIBRARIES})
+
+install(TARGETS eglinfo DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT "runtime")

--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -1,0 +1,53 @@
+# - Try to Find EGL
+# Once done, this will define
+#
+#  EGL_FOUND - system has EGL installed.
+#  EGL_INCLUDE_DIRS - directories which contain the EGL headers.
+#  EGL_LIBRARIES - libraries required to link against EGL.
+#  EGL_DEFINITIONS - Compiler switches required for using EGL.
+#
+# Copyright (C) 2012 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+find_package(PkgConfig)
+
+pkg_check_modules(PC_EGL egl)
+
+if (PC_EGL_FOUND)
+    set(EGL_DEFINITIONS ${PC_EGL_CFLAGS_OTHER})
+endif ()
+
+find_path(EGL_INCLUDE_DIRS NAMES EGL/egl.h
+    HINTS ${PC_EGL_INCLUDEDIR} ${PC_EGL_INCLUDE_DIRS}
+)
+
+set(EGL_NAMES ${EGL_NAMES} egl EGL)
+find_library(EGL_LIBRARIES NAMES ${EGL_NAMES}
+    HINTS ${PC_EGL_LIBDIR} ${PC_EGL_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(EGL DEFAULT_MSG EGL_INCLUDE_DIRS EGL_LIBRARIES)
+
+mark_as_advanced(EGL_INCLUDE_DIRS EGL_LIBRARIES)


### PR DESCRIPTION
 * This allows to build the project without requiring using qmake,
   which is usually a bigger (or hard to get) dependency than CMake.